### PR TITLE
Fix apple tv input issues.

### DIFF
--- a/Project/Oquonie/Controls_AppleTV.swift
+++ b/Project/Oquonie/Controls_AppleTV.swift
@@ -5,79 +5,68 @@
 import SpriteKit
 import Foundation
 
-extension MainViewController
+class TVViewController : MainViewController
 {
-	func installGestures()
+    override func installGestures()
 	{
-		let swipeRightUp = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeRightUp.direction = UISwipeGestureRecognizerDirection.Right.union(.Up)
-		self.view.addGestureRecognizer(swipeRightUp)
-		
-		let swipeRightDown = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeRightDown.direction = UISwipeGestureRecognizerDirection.Down.union(.Right)
-		self.view.addGestureRecognizer(swipeRightDown)
-		
-		let swipeLeftUp = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeLeftUp.direction = UISwipeGestureRecognizerDirection.Up.union(.Left)
-		self.view.addGestureRecognizer(swipeLeftUp)
-		
-		let swipeLeftDown = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeLeftDown.direction = UISwipeGestureRecognizerDirection.Left.union(.Down)
-		self.view.addGestureRecognizer(swipeLeftDown)
-		
-		let swipeRight = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeRight.direction = UISwipeGestureRecognizerDirection.Right
-		swipeRight.requireGestureRecognizerToFail(swipeRightUp)
-		swipeRight.requireGestureRecognizerToFail(swipeRightDown)
-		self.view.addGestureRecognizer(swipeRight)
-		
-		let swipeDown = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeDown.direction = UISwipeGestureRecognizerDirection.Down
-		swipeDown.requireGestureRecognizerToFail(swipeLeftDown)
-		swipeDown.requireGestureRecognizerToFail(swipeRightDown)
-		self.view.addGestureRecognizer(swipeDown)
-		
-		let swipeUp = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeUp.direction = UISwipeGestureRecognizerDirection.Up
-		swipeUp.requireGestureRecognizerToFail(swipeRightUp)
-		swipeUp.requireGestureRecognizerToFail(swipeLeftUp)
-		self.view.addGestureRecognizer(swipeUp)
-		
-		let swipeLeft = UISwipeGestureRecognizer(target: self, action: "respondToSwipeGesture:")
-		swipeLeft.direction = UISwipeGestureRecognizerDirection.Left
-		swipeLeft.requireGestureRecognizerToFail(swipeLeftUp)
-		swipeLeft.requireGestureRecognizerToFail(swipeLeftDown)
-		self.view.addGestureRecognizer(swipeLeft)
+        let panGesture = UIPanGestureRecognizer(target: self, action: "respondToPanGesture:")
+        self.view.addGestureRecognizer(panGesture)
 	}
-	
-	func respondToSwipeGesture(gesture: UIGestureRecognizer)
-	{
-		if player == nil { return }
-		
-		if overlay.alpha > 0 {
-			player.hideOverlay()
-		}
-		
-		if dialog.isActive == true {
-			dialog.hideModal()
-			return
-		}
-		
-		if let swipeGesture = gesture as? UISwipeGestureRecognizer {
-			switch swipeGesture.direction {
-			case UISwipeGestureRecognizerDirection.Right, UISwipeGestureRecognizerDirection.Right.union(.Up):
-				player.move(1, y: 0)
-			case UISwipeGestureRecognizerDirection.Down, UISwipeGestureRecognizerDirection.Down.union(.Right):
-				player.move(0, y: -1)
-			case UISwipeGestureRecognizerDirection.Left, UISwipeGestureRecognizerDirection.Left.union(.Down):
-				player.move(-1, y: 0)
-			case UISwipeGestureRecognizerDirection.Up, UISwipeGestureRecognizerDirection.Up.union(.Left):
-				player.move(0, y: 1)
-			default:
-				break
-			}
-		}
-	}
+
+    func respondToPanGesture(gesture: UIGestureRecognizer)
+    {
+        if player == nil { return }
+
+        // Only use the gesture if it's over.
+        if gesture.state != UIGestureRecognizerState.Ended
+        {
+            return
+        }
+
+        if let gesture = gesture as? UIPanGestureRecognizer
+        {
+            // Normalize the points to the remote size.
+            var point = gesture.translationInView(view)
+            point.x = point.x / view.bounds.width
+            point.y = point.y / view.bounds.height
+
+            // Cancel on smalll accidental pans.
+            if distanceBetweenTwoPoints(CGPoint.zero, b: point) < 0.05
+            {
+                return
+            }
+
+            // Offset the angle so 'right' starts at 15 degrees from straight up and goes clockwise. And is always between 0 and 360
+            let angle = fmod((Double(atan2(point.y, point.x)) * 180.0 / M_PI) + 720.0 + 75.0, 360.0)
+
+            if overlay.alpha > 0 {
+                player.hideOverlay()
+            }
+
+            if dialog.isActive == true {
+                dialog.hideModal()
+                return
+            }
+
+            // Go around the touch area clockwise.
+            if angle < 90
+            {
+                player.move(1, y: 0)
+            }
+            else if angle < 180
+            {
+                player.move(0, y: -1)
+            }
+            else if angle < 270
+            {
+                player.move(-1, y: 0)
+            }
+            else
+            {
+                player.move(0, y: 1)
+            }
+        }
+    }
 
 	override func pressesEnded(presses: Set<UIPress>, withEvent event: UIPressesEvent?)
 	{

--- a/Project/Oquonie/MainViewController.swift
+++ b/Project/Oquonie/MainViewController.swift
@@ -39,6 +39,7 @@ class MainViewController: UIViewController
 			scene.scaleMode = .AspectFit
 			skView.presentScene(scene)
 			scene.start()
+            self.installGestures()
 		}
 	}
 	
@@ -46,4 +47,6 @@ class MainViewController: UIViewController
 	{
 		
 	}
+
+    func installGestures() {}
 }

--- a/Project/Oquonie/Oquonie AppleTV/Base.lproj/AppleTV.storyboard
+++ b/Project/Oquonie/Oquonie AppleTV/Base.lproj/AppleTV.storyboard
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="9060" systemVersion="15C47a" targetRuntime="AppleTV" propertyAccessControl="none" initialViewController="499-42-d0g">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="AppleTV" propertyAccessControl="none" initialViewController="499-42-d0g">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
     </dependencies>
     <scenes>
-        <!--Main View Controller-->
+        <!--View Controller-->
         <scene sceneID="dEh-eV-dlg">
             <objects>
-                <viewController id="499-42-d0g" customClass="MainViewController" customModule="Oquonie_AppleTV" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="499-42-d0g" customClass="TVViewController" customModule="Oquonie_AppleTV" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" multipleTouchEnabled="YES" contentMode="scaleToFill" id="weF-Pa-zaM" customClass="SKView">
                         <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
- Use a MainViewController subclass instead of extension.
- Fire installGestures on apple tv.
- Change swipe gestures to single pan gesture that moves based on the
  direction of the pan.
